### PR TITLE
Various fixes

### DIFF
--- a/lib/ec2/instances.rb
+++ b/lib/ec2/instances.rb
@@ -37,11 +37,11 @@ OptionParser.new do |opts|
     options[:disable_term_protection] = true
   end
 
-  opts.on('--terminate', 'OPTIONAL: This will terminate the specified instances. Must be combined with -s') do
+  opts.on('--terminate', 'OPTIONAL: This will terminate the specified instances.') do
     options[:terminate] = true
   end
 
-  opts.on('--rebuild', 'OPTIONAL: This will terminate and relaunch the specified instances. Must be combined with -s') do
+  opts.on('--rebuild', 'OPTIONAL: This will terminate and relaunch the specified instances.') do
     options[:rebuild] = true
   end
   
@@ -62,7 +62,7 @@ OptionParser.new do |opts|
     opts.parse!
     throw Exception unless ((options.include? :environment) && (options.include? :product)) || options[:list]
     if options[:terminate] || options[:rebuild]
-      throw Exception unless (options[:disable_term_protection] && options[:servers])
+      throw Exception unless (options[:disable_term_protection])
     end
 
   rescue
@@ -137,7 +137,7 @@ vpc_security_groups = Vominator::EC2.get_security_group_name_ids_hash(ec2, puke_
 
 instances.each do |instance|
   hostname = instance.keys[0]
-  fqdn = "#{hostname}.#{options[:environment]}.#{puke_config['domain']}"
+  fqdn = "#{hostname}.#{puke_config['domain']}"
   instance_type = instance['type'][options[:environment]]
   instance_ip = instance['ip'].sub('OCTET',puke_config['octet'])
   instance_security_groups = instance['security_groups'].map { |sg| "#{options[:environment]}-#{sg}"}.uniq.sort

--- a/lib/ec2/instances.rb
+++ b/lib/ec2/instances.rb
@@ -168,8 +168,8 @@ instances.each do |instance|
   #Check to see if the subnet exists for the instance. If not we should create it.
   subnet = "#{instance_ip.rpartition('.')[0]}.0/24"
   unless existing_subnets[subnet]
-    unless test?("Would create a subnet for #{subnet} in #{instance['az']}")
-      existing_subnets[subnet] = Vominator::EC2.create_subnet(ec2, subnet, instance['az'], puke_config['vpc_id'])
+    unless test?("Would create a subnet for #{subnet} in #{instance['az']} and associate with the appropriate routing table")
+      existing_subnets[subnet] = Vominator::EC2.create_subnet(ec2, subnet, instance['az'], puke_config['vpc_id'], instance['az'])
       LOGGER.success("Created #{subnet} in #{instance['az']} for #{fqdn}")
     end
   end

--- a/lib/ec2/instances.rb
+++ b/lib/ec2/instances.rb
@@ -169,7 +169,7 @@ instances.each do |instance|
   subnet = "#{instance_ip.rpartition('.')[0]}.0/24"
   unless existing_subnets[subnet]
     unless test?("Would create a subnet for #{subnet} in #{instance['az']} and associate with the appropriate routing table")
-      existing_subnets[subnet] = Vominator::EC2.create_subnet(ec2, subnet, instance['az'], puke_config['vpc_id'], instance['az'])
+      existing_subnets[subnet] = Vominator::EC2.create_subnet(ec2, subnet, instance['az'], puke_config['vpc_id'], puke_config['route_tables'][instance['az']])
       LOGGER.success("Created #{subnet} in #{instance['az']} for #{fqdn}")
     end
   end

--- a/lib/vominator/ec2.rb
+++ b/lib/vominator/ec2.rb
@@ -55,9 +55,17 @@ module Vominator
       return ami
     end
 
-    def self.create_subnet(resource, subnet, az, vpc_id)
+    def self.create_subnet(resource, subnet, az, vpc_id, route_table_id=nil)
       subnet = resource.vpcs(filters: [{name: 'vpc-id', values: [vpc_id]}]).first.create_subnet(:cidr_block => subnet, :availability_zone => az)
+      if route_table_id
+        route_table = Vominator::EC2.get_route_table(resource,route_table_id)
+        route_table.associate_with_subnet(subnet_id: subnet.subnet_id)
+      end
       return subnet
+    end
+
+    def self.get_route_table(resource, route_table_id)
+      return resource.route_tables(filters: [{name: 'route-table-id', values: [route_table_id]}]).first
     end
 
     def self.get_termination_protection(client, instance_id)


### PR DESCRIPTION
dont require a list of services when terminating or rebuilding instances since we specify an environment/product combo. 

created private subnets will now be mapped to the appropriate private routing table.