### PR TITLE
multi account support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ See Usage for details about puke
 2. Create ~/.vominator.yaml
 ```
 ---
-access_key_id: AWS_SECRET_KEY
-secret_access_key: AWS_SECRET_ACCESS_KEY
 configuration_path: Location to puke
 key_pair_name: infrastructure@example.com
 instances_file: Location for cache file IE /Users/foo/.vominator/instances-metadata
@@ -69,6 +67,7 @@ Usage: vominate vpc create [options]
         --parent-domain PARENT DOMAIN
                                      REQUIRED: The parent domain name that will be used to create a seperate subdomain zone file for the new environment. IE, if you provide foo.org and your environment as bar, this will yield a new Route 53 zone file called bar.foo.org
         --cidr-block CIDR Block      REQUIRED: The network block for the new environment. This must be a /16 and the second octet should be unique for this environment. IE. 10.123.0.0/16
+        --account ACCOUNT            REQUIRED: The AWS account that you want to create this VPC in
     -d, --debug                      OPTIONAL: debug output
     -h, --help                       OPTIONAL: Display this screen 
 ```

--- a/lib/ec2/instances.rb
+++ b/lib/ec2/instances.rb
@@ -113,7 +113,8 @@ unless instances
   LOGGER.fatal('Unable to load instances. Make sure the product is correctly defined for the environment you have selected.')
 end
 
-#Get ec2 connection, which is then passed to specific functions. Maybe a better way to do this?
+#Get ec2 connection, which is then passed to specific functions. Maybe a better way to do thisi?
+Aws.config[:credentials] = Aws::SharedCredentials.new(:profile_name => puke_config['account'])
 ec2 = Aws::EC2::Resource.new(region: puke_config['region_name'])
 ec2_client = Aws::EC2::Client.new(region: puke_config['region_name'])
 

--- a/lib/ec2/security_groups.rb
+++ b/lib/ec2/security_groups.rb
@@ -104,6 +104,7 @@ unless puke_security_groups
   LOGGER.fatal('Unable to load security groups . Make sure the product is correctly defined for the environment you have selected and that a security_groups.yaml file exists with at least one group defined.')
 end
 
+Aws.config[:credentials] = Aws::SharedCredentials.new(:profile_name => puke_config['account'])
 ec2_client = Aws::EC2::Client.new(region: puke_config['region_name'])
 
 

--- a/lib/ec2/ssm.rb
+++ b/lib/ec2/ssm.rb
@@ -58,6 +58,7 @@ unless test?('Vominator is running in test mode. It will NOT make any changes.')
   end
 end
 
+Aws.config[:credentials] = Aws::SharedCredentials.new(:profile_name => puke_config['account'])
 ssm = Aws::SSM::Client.new(region: puke_config['region_name'])
 
 aws_documents = Vominator::SSM.get_documents(ssm)

--- a/lib/vominator/aws.rb
+++ b/lib/vominator/aws.rb
@@ -2,8 +2,6 @@ require 'aws-sdk'
 require_relative 'vominator'
 require_relative 'constants'
 
-Aws.config[:credentials] = Aws::Credentials.new(VOMINATOR_CONFIG['access_key_id'], VOMINATOR_CONFIG['secret_access_key'])
-
 module Vominator
   class AWS
     def self.get_availability_zones(ec2_client)

--- a/spec/lib/vominator/vominator_spec.rb
+++ b/spec/lib/vominator/vominator_spec.rb
@@ -23,8 +23,6 @@ describe Vominator do
       subject { vominator_config }
 
       it { is_expected.not_to be false }
-      it { is_expected.to include('access_key_id' => 'DUMMY_ACCESS_KEY') }
-      it { is_expected.to include('secret_access_key' => 'DUMMY_SECRET_KEY') }
       it { is_expected.to include('configuration_path' => 'test/puke') }
       it { is_expected.to include('key_pair_name' => 'ci@example.com') }
       it { is_expected.to include('chef_client_key' => 'ci.pem') }

--- a/test/puke/config.yaml
+++ b/test/puke/config.yaml
@@ -1,5 +1,6 @@
 ---
 test:
+  account: example-account
   vpc_id: vpc-ada2d4c8
   region_name: us-east-1
   zone: Z2IOTRJNNABNJ

--- a/test/vominator.yaml
+++ b/test/vominator.yaml
@@ -1,6 +1,4 @@
 ---
-access_key_id: DUMMY_ACCESS_KEY
-secret_access_key: DUMMY_SECRET_KEY
 configuration_path: test/puke
 key_pair_name: ci@example.com
 chef_client_key: ci.pem


### PR DESCRIPTION
Resolves issue #29 allowing replication of VPCs into multiple AWS accounts.

Also moves authentication to ~/.aws/credentials file, which falls inline with other AWS tools and prevents duplication.