### PR TITLE
Support for different AMI's by environment and instance

### DIFF
--- a/lib/ec2/instances.rb
+++ b/lib/ec2/instances.rb
@@ -159,7 +159,7 @@ instances.each do |instance|
   end
 
   if instance['ami']
-    ami = instance['ami']
+    ami = instance['ami'][options[:environment]] || instance['ami']
   else
     ami = Vominator::EC2.get_ami(puke_config,instance_type,instance['family'])
   end


### PR DESCRIPTION
Need support for different AMI ID's per environment to handle privately owned/shared AMI's.